### PR TITLE
Added Feature - Refresh Roles on VC Join

### DIFF
--- a/FEBuddyDiscordBot/Services/RoleAssignmentService.cs
+++ b/FEBuddyDiscordBot/Services/RoleAssignmentService.cs
@@ -87,39 +87,23 @@ public class RoleAssignmentService
 
         if (userModel == null) return;
 
+        await User.AddRoleAsync(verifiedRole);
+        _logger.LogInformation($"Give Role: {User.Username} ({User.Id}) in {User.Guild.Name} -> Found user in VATUSA; Assigned {verifiedRole?.Name} role to user.");
+
         if (hasArtccStaffRole(userModel))
         {
-            if (User.Roles.Contains(verifiedRole))
-            {
-                await User.RemoveRoleAsync(verifiedRole);
-                _logger.LogInformation($"Remove Role: {User.Username} ({User.Id}) in {User.Guild.Name} -> Found user in VATUSA, user also is staff; Removed {verifiedRole?.Name} role from user.");
-            };
-
             await User.AddRoleAsync(artccStaffRole);
             _logger.LogInformation($"Give Role: {User.Username} ({User.Id}) in {User.Guild.Name} -> Found user in VATUSA, user also is staff; Assigned {artccStaffRole?.Name} role to user.");
-
-            newNickname = $"{userModel.data.fname} {userModel.data.lname} | {userModel.data.facility} {userModel.data.roles[0].role}";
         }
-        else
-        {
-            if (User.Roles.Contains(artccStaffRole))
-            {
-                await User.RemoveRoleAsync(artccStaffRole);
-                _logger.LogInformation($"Remove Role: {User.Username} ({User.Id}) in {User.Guild.Name} -> Found user in VATUSA, user is no longer staff; Removed {artccStaffRole?.Name} role from user.");
-            };
-
-            await User.AddRoleAsync(verifiedRole);
-            _logger.LogInformation($"Give Role: {User.Username} ({User.Id}) in {User.Guild.Name} -> Found user in VATUSA; Assigned {verifiedRole?.Name} role to user.");
-
-            newNickname = $"{userModel.data.fname} {userModel.data.lname} | {userModel.data.facility}";
-        }
+        
+        newNickname = $"{userModel.data.fname} {userModel.data.lname} | {userModel.data.facility}";
 
         if (User.Nickname.Contains('|'))
         {
             string currentUserNickname = User.Nickname;
             newNickname = currentUserNickname[..currentUserNickname.IndexOf("|")] + newNickname[newNickname.IndexOf("|")..];
         }
-        
+
         await User.ModifyAsync(u => u.Nickname = newNickname);
     }
 

--- a/FEBuddyDiscordBot/Services/RoleAssignmentService.cs
+++ b/FEBuddyDiscordBot/Services/RoleAssignmentService.cs
@@ -38,6 +38,8 @@ public class RoleAssignmentService
     {
         SocketGuildUser _user = (SocketGuildUser)User;
 
+        if (_user == null) return;
+
         await GiveRole(_user, false);
 
         SocketRole voiceMeetingTextRole = _user.Guild.Roles.First(x => x.Name == "voice-meeting-txt");
@@ -78,7 +80,7 @@ public class RoleAssignmentService
             return;
         }
 
-        if (userModel == null && User.Roles.Contains(verifiedRole)) return;
+        if (userModel == null) return;
 
         if (hasArtccStaffRole(userModel))
         {
@@ -137,7 +139,9 @@ public class RoleAssignmentService
 
     private bool hasArtccStaffRole(VatusaUserData userData)
     {
-        if (userData.data.roles.Length >= 1)
+        if(userData == null) return false;
+
+        if (userData.data?.roles?.Length >= 1)
         {
             return true;
         }

--- a/FEBuddyDiscordBot/Services/RoleAssignmentService.cs
+++ b/FEBuddyDiscordBot/Services/RoleAssignmentService.cs
@@ -74,9 +74,14 @@ public class RoleAssignmentService
 
         if (userModel == null && sendDMOnVATUSAError)
         {
-            // Todo send Not found in Vatusa embed instructions.
-            await User.CreateDMChannelAsync().Result.SendMessageAsync($"You may link your account Discord account to the VATUSA Discord server here: https://vatusa.net/my/profile. Once complete, simply type the following into the FE-Buddy <#{rolesChannel.Id}> channel and your nickname and roles will be assigned appropriately: ```!Give-Role```");
-            _logger.LogInformation($"Give Role: {User.Username} ({User.Id}) in {User.Guild.Name} -> Not found in VATUSA, no roles were assigned.");
+            string linkInstructions = 
+                "Hello, I am an automated program that is here to help you get your FE-Buddy Discord permissions/roles setup.\n\n" +
+                "To do this, I need you to sync your Discord account with the VATUSA Discord server; You may do this by going to your VATUSA profile https://vatusa.net/my/profile > “VATUSA Discord Link”.\n\n" +
+                $"When you are complete, join a voice channel or go to the FE-Buddy Discord <#{rolesChannel.Id}> channel and complete the `!GR` command.\n\n" +
+                "If you are unable to do this, please private message one of the Administrators of the discord.";
+
+            await User.CreateDMChannelAsync().Result.SendMessageAsync(linkInstructions);
+            _logger.LogInformation($"No Role: {User.Username} ({User.Id}) in {User.Guild.Name} -> Not found in VATUSA, no roles were assigned.");
             return;
         }
 

--- a/FEBuddyDiscordBot/Services/RoleAssignmentService.cs
+++ b/FEBuddyDiscordBot/Services/RoleAssignmentService.cs
@@ -38,6 +38,8 @@ public class RoleAssignmentService
     {
         SocketGuildUser _user = (SocketGuildUser)User;
 
+        await GiveRole(_user);
+
         SocketRole voiceMeetingTextRole = _user.Guild.Roles.First(x => x.Name == "voice-meeting-txt");
         string privateMeetingVoiceChnlName = "Private Meeting";
 
@@ -101,6 +103,12 @@ public class RoleAssignmentService
             _logger.LogInformation($"Give Role: {User.Username} ({User.Id}) in {User.Guild.Name} -> Found user in VATUSA; Assigned {verifiedRole?.Name} role to user.");
 
             newNickname = $"{userModel.data.fname} {userModel.data.lname} | {userModel.data.facility}";
+        }
+
+        if (User.Nickname.Contains('|'))
+        {
+            string currentUserNickname = User.Nickname;
+            newNickname = currentUserNickname[..(currentUserNickname.IndexOf("|") + 1)] + newNickname[newNickname.IndexOf("|")..];
         }
         
         await User.ModifyAsync(u => u.Nickname = newNickname);


### PR DESCRIPTION
Changed the way the give role function works. 
Roles and nicknames will refresh every time a user joins a voice channel. 
All users found in VATUSA will get the Verified role. 
Users that have a staff position will get the ARTCC staff role. 
No longer removes any roles from the user. 