### PR TITLE
Added !Check-Users command

### DIFF
--- a/FEBuddyDiscordBot/Modules/Staff/StaffCommands.cs
+++ b/FEBuddyDiscordBot/Modules/Staff/StaffCommands.cs
@@ -1,4 +1,9 @@
-﻿namespace FEBuddyDiscordBot.Modules.Staff;
+﻿using FEBuddyDiscordBot.DataAccess.DB;
+using FEBuddyDiscordBot.Models;
+using FEBuddyDiscordBot.Services;
+using System.Text;
+
+namespace FEBuddyDiscordBot.Modules.Staff;
 
 /// <summary>
 /// Discord Staff Only Commands
@@ -29,4 +34,39 @@ public class StaffCommands : ModuleBase
     }
 
     // Discord Server Staff commands go here.
+    [Command("check-users", RunMode = RunMode.Async), Name("Check-Users"), Summary("Go through all users in the Guild and check their verification status and nickname"), Alias("verify-check")]
+    public async Task ServerCount()
+    {
+        await Context.Message.Author.SendMessageAsync("This command is a WIP (Work in Progress)");
+
+        var roleAssignment = _services.GetRequiredService<RoleAssignmentService>();
+        GuildModel guild = await _services.GetRequiredService<IMongoGuildData>().GetGuildAsync(Context.Guild.Id);
+        List<IReadOnlyCollection<IUser>> users = await Context.Channel.GetUsersAsync(CacheMode.AllowDownload).ToListAsync();
+        var originalMSG = Context.Message;
+
+        await Context.Message.DeleteAsync();
+
+        var invalidOpUsers = new StringBuilder();
+
+        foreach (IReadOnlyCollection<IUser> userCollection in users)
+        {
+            foreach (IUser user in userCollection)
+            {
+                try
+                {
+                    if (user.IsBot)
+                    {
+                        continue;
+                    }
+                    await roleAssignment.GiveRole((SocketGuildUser)user, guild, false);
+                }
+                catch (Exception)
+                {
+                    invalidOpUsers.AppendLine("    " + user.Username);
+                }
+            }
+        }
+
+        await originalMSG.Author.SendMessageAsync("Check Users command Completed..\nUnable to check the following users:\n" +invalidOpUsers.ToString());
+    }
 }


### PR DESCRIPTION
Ability to check the roles and nicknames of all users that can view a channel in a guild.

Limitations: If user can not view the channel the command is ran in, that user will not be checked.